### PR TITLE
Make the process of updating Support Rotations atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ and locate the relevant ID.
 
 This will do the following:
 
-- Delete all upcoming support rota bookings in Productive,
-- Fetch all support rota info from the API, importing them into Productive as a booking against the Support project
-  for the appropriate person.
+This will fetch all support project bookings from Productive and the Support Rota, deleting any that are
+present in Productive, but not the Support Rota, and creating any that are present in the Support Rota,
+but not Productive.
 
 ```bash
 bundle exec rake support_rota_to_productive:import:run

--- a/lib/productive/booking.rb
+++ b/lib/productive/booking.rb
@@ -1,0 +1,17 @@
+module Productive
+  class Booking
+    def to_support_rotation
+      SupportRotaToProductive::SupportRotation.new(
+        employee: employee,
+        date: started_on.to_date,
+        productive_booking: self
+      )
+    end
+
+    private
+
+    def employee
+      SupportRotaToProductive::Employee.new(email: person.email)
+    end
+  end
+end

--- a/lib/support_rota_to_productive.rb
+++ b/lib/support_rota_to_productive.rb
@@ -14,5 +14,8 @@ require "support_rota_to_productive/send_to_productive"
 require "support_rota_to_productive/import"
 require "support_rota_to_productive/support_rotation"
 require "support_rota_to_productive/support_rota_client"
+
+require "productive/booking"
+
 module SupportRotaToProductive
 end

--- a/lib/support_rota_to_productive.rb
+++ b/lib/support_rota_to_productive.rb
@@ -10,7 +10,7 @@ Productive.configure do |config|
 end
 
 require "support_rota_to_productive/employee"
-require "support_rota_to_productive/booking"
+require "support_rota_to_productive/send_to_productive"
 require "support_rota_to_productive/import"
 require "support_rota_to_productive/support_rotation"
 require "support_rota_to_productive/support_rota_client"

--- a/lib/support_rota_to_productive.rb
+++ b/lib/support_rota_to_productive.rb
@@ -18,4 +18,6 @@ require "support_rota_to_productive/support_rota_client"
 require "productive/booking"
 
 module SupportRotaToProductive
+  SUPPORT_PROJECT_ID = ENV.fetch("SUPPORT_PROJECT_ID")
+  SUPPORT_SERVICE_ID = ENV.fetch("SUPPORT_SERVICE_ID")
 end

--- a/lib/support_rota_to_productive.rb
+++ b/lib/support_rota_to_productive.rb
@@ -20,4 +20,6 @@ require "productive/booking"
 module SupportRotaToProductive
   SUPPORT_PROJECT_ID = ENV.fetch("SUPPORT_PROJECT_ID")
   SUPPORT_SERVICE_ID = ENV.fetch("SUPPORT_SERVICE_ID")
+
+  LOGGER = Logger.new($stdout)
 end

--- a/lib/support_rota_to_productive/import.rb
+++ b/lib/support_rota_to_productive/import.rb
@@ -5,21 +5,41 @@ module SupportRotaToProductive
     end
 
     def run
-      delete_all_future_bookings
-      create_bookings_from_support_rotations
+      added = support_rotations_to_add.map do |support_rotation|
+        SendToProductive.new(support_rotation, @dry_run).save
+      end.count { |item| item != false }
+
+      deleted = support_rotations_to_delete.each do |support_rotation|
+        LOGGER.info("Deleting support shift for #{support_rotation.employee.email} on #{support_rotation.date}")
+        support_rotation.productive_booking.destroy unless @dry_run
+      end.reduce(0) { |count| count + 1 }
+
+      LOGGER.info("==========================================================")
+      LOGGER.info("Run complete!")
+      LOGGER.info("#{added} item(s) added, #{deleted} item(s) deleted")
+      LOGGER.info("==========================================================")
     end
 
     private
 
-    def delete_all_future_bookings
-      SendToProductive.delete_all_future_bookings(@dry_run)
+    def support_rotations_from_api
+      @support_rotations_from_api ||= SupportRotation.from_support_rota
     end
 
-    def create_bookings_from_support_rotations
-      SupportRotation.from_support_rota.each do |rotation|
-        booking = SupportRotaToProductive::SendToProductive.new(rotation, @dry_run)
-        booking.save
-      end
+    def support_rotations_from_productive
+      @support_rotations_from_productive ||= SupportRotation.from_productive
+    end
+
+    def common_support_rotations
+      support_rotations_from_api & support_rotations_from_productive
+    end
+
+    def support_rotations_to_add
+      (support_rotations_from_api - common_support_rotations)
+    end
+
+    def support_rotations_to_delete
+      (support_rotations_from_productive - common_support_rotations)
     end
   end
 end

--- a/lib/support_rota_to_productive/import.rb
+++ b/lib/support_rota_to_productive/import.rb
@@ -16,7 +16,7 @@ module SupportRotaToProductive
     end
 
     def create_bookings_from_support_rotations
-      SupportRotation.all.each do |rotation|
+      SupportRotation.from_support_rota.each do |rotation|
         booking = SupportRotaToProductive::SendToProductive.new(rotation, @dry_run)
         booking.save
       end

--- a/lib/support_rota_to_productive/import.rb
+++ b/lib/support_rota_to_productive/import.rb
@@ -12,12 +12,12 @@ module SupportRotaToProductive
     private
 
     def delete_all_future_bookings
-      Booking.delete_all_future_bookings(@dry_run)
+      SendToProductive.delete_all_future_bookings(@dry_run)
     end
 
     def create_bookings_from_support_rotations
       SupportRotation.all.each do |rotation|
-        booking = SupportRotaToProductive::Booking.new(rotation, @dry_run)
+        booking = SupportRotaToProductive::SendToProductive.new(rotation, @dry_run)
         booking.save
       end
     end

--- a/lib/support_rota_to_productive/send_to_productive.rb
+++ b/lib/support_rota_to_productive/send_to_productive.rb
@@ -1,5 +1,5 @@
 module SupportRotaToProductive
-  class Booking
+  class SendToProductive
     SUPPORT_SERVICE_ID = ENV.fetch("SUPPORT_SERVICE_ID")
     SUPPORT_PROJECT_ID = ENV.fetch("SUPPORT_PROJECT_ID")
 

--- a/lib/support_rota_to_productive/send_to_productive.rb
+++ b/lib/support_rota_to_productive/send_to_productive.rb
@@ -1,8 +1,5 @@
 module SupportRotaToProductive
   class SendToProductive
-    SUPPORT_SERVICE_ID = ENV.fetch("SUPPORT_SERVICE_ID")
-    SUPPORT_PROJECT_ID = ENV.fetch("SUPPORT_PROJECT_ID")
-
     LOGGER = Logger.new($stdout)
 
     attr_reader :employee, :start_date, :end_date, :dry_run, :productive_person
@@ -25,7 +22,7 @@ module SupportRotaToProductive
 
     class << self
       def delete_all_future_bookings(dry_run)
-        future_bookings = Productive::Booking.where(project_id: SUPPORT_PROJECT_ID, after: Date.today).all
+        future_bookings = Productive::Booking.where(project_id: SupportRotaToProductive::SUPPORT_PROJECT_ID, after: Date.today).all
 
         future_bookings.each do |booking|
           LOGGER.info("Deleting support shift for #{booking.person.email} on #{booking.started_on}")

--- a/lib/support_rota_to_productive/send_to_productive.rb
+++ b/lib/support_rota_to_productive/send_to_productive.rb
@@ -1,7 +1,5 @@
 module SupportRotaToProductive
   class SendToProductive
-    LOGGER = Logger.new($stdout)
-
     attr_reader :employee, :start_date, :end_date, :dry_run, :productive_person
 
     def initialize(support_rotation, dry_run)
@@ -20,17 +18,6 @@ module SupportRotaToProductive
       end
     end
 
-    class << self
-      def delete_all_future_bookings(dry_run)
-        future_bookings = Productive::Booking.where(project_id: SupportRotaToProductive::SUPPORT_PROJECT_ID, after: Date.today).all
-
-        future_bookings.each do |booking|
-          LOGGER.info("Deleting support shift for #{booking.person.email} on #{booking.started_on}")
-          booking.destroy unless dry_run
-        end
-      end
-    end
-
     private
 
     def employee_assigned_to_support_project?(employee)
@@ -42,7 +29,7 @@ module SupportRotaToProductive
         unless employee_assigned_to_support_project?(employee)
           assignment = assign_employee_to_support_project(employee)
           if assignment.save
-            LOGGER.info("#{employee.email} assigned to Support project id: #{SUPPORT_PROJECT_ID}")
+            SupportRotaToProductive::LOGGER.info("#{employee.email} assigned to Support project id: #{SUPPORT_PROJECT_ID}")
           end
         end
 

--- a/lib/support_rota_to_productive/support_rotation.rb
+++ b/lib/support_rota_to_productive/support_rotation.rb
@@ -3,6 +3,16 @@ module SupportRotaToProductive
     include ActiveModel::Model
     attr_accessor :date, :employee
 
+    def eql?(other)
+      employee.email == other.employee.email &&
+        date == other.date
+    end
+    alias_method :==, :eql?
+
+    def hash
+      (date.hash ^ employee.email.hash)
+    end
+
     class << self
       def all
         result = []

--- a/lib/support_rota_to_productive/support_rotation.rb
+++ b/lib/support_rota_to_productive/support_rotation.rb
@@ -1,7 +1,7 @@
 module SupportRotaToProductive
   class SupportRotation
     include ActiveModel::Model
-    attr_accessor :date, :employee
+    attr_accessor :date, :employee, :productive_booking
 
     def eql?(other)
       employee.email == other.employee.email &&

--- a/lib/support_rota_to_productive/support_rotation.rb
+++ b/lib/support_rota_to_productive/support_rotation.rb
@@ -14,7 +14,7 @@ module SupportRotaToProductive
     end
 
     class << self
-      def all
+      def from_support_rota
         result = []
         result << JSON.parse(client.get(developer_endpoint)) if ENV["IMPORT_DEV_IN_HOURS"].eql?("true")
         result << JSON.parse(client.get(ops_endpoint)) if ENV["IMPORT_OPS_IN_HOURS"].eql?("true")
@@ -22,6 +22,10 @@ module SupportRotaToProductive
         result.flatten.map do |support_day|
           new(values_for(support_day))
         end
+      end
+
+      def from_productive
+        Productive::Booking.where(project_id: SUPPORT_PROJECT_ID, after: Date.today).all.map(&:to_support_rotation)
       end
 
       private

--- a/spec/factories/booking.rb
+++ b/spec/factories/booking.rb
@@ -99,7 +99,7 @@ FactoryBot.define do
       @json["data"] << evaluator.json
       @json["included"] << evaluator.included
 
-      url = "https://api.productive.io/api/v2/bookings?filter%5Bafter%5D=#{Date.today}&filter%5Bproject_id%5D=#{SupportRotaToProductive::SendToProductive::SUPPORT_PROJECT_ID}"
+      url = "https://api.productive.io/api/v2/bookings?filter%5Bafter%5D=#{Date.today}&filter%5Bproject_id%5D=#{SupportRotaToProductive::SUPPORT_PROJECT_ID}"
       WebMock.stub_request(:get, url)
         .to_return(
           status: 200,

--- a/spec/factories/booking.rb
+++ b/spec/factories/booking.rb
@@ -99,7 +99,7 @@ FactoryBot.define do
       @json["data"] << evaluator.json
       @json["included"] << evaluator.included
 
-      url = "https://api.productive.io/api/v2/bookings?filter%5Bafter%5D=#{Date.today}&filter%5Bproject_id%5D=#{SupportRotaToProductive::Booking::SUPPORT_PROJECT_ID}"
+      url = "https://api.productive.io/api/v2/bookings?filter%5Bafter%5D=#{Date.today}&filter%5Bproject_id%5D=#{SupportRotaToProductive::SendToProductive::SUPPORT_PROJECT_ID}"
       WebMock.stub_request(:get, url)
         .to_return(
           status: 200,

--- a/spec/productive/booking_spec.rb
+++ b/spec/productive/booking_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe Productive::Booking do
+  let(:employee) { create(:employee) }
+  let(:booking) { create(:booking, employee: employee) }
+
+  describe "#to_support_rotation" do
+    subject { booking.to_support_rotation }
+
+    it "converts the booking to a support rotation" do
+      expect(subject).to be_a(SupportRotaToProductive::SupportRotation)
+      expect(subject.date).to eq(booking.started_on.to_date)
+      expect(subject.employee.email).to eq(booking.person.email)
+      expect(subject.productive_booking).to eq(booking)
+    end
+  end
+end

--- a/spec/support/service_stubs.rb
+++ b/spec/support/service_stubs.rb
@@ -10,32 +10,9 @@ module ServiceStubs
       .to_return(status: 200, body: "", headers: {})
   end
 
-  def stub_booking_create(employee:)
+  def stub_booking_create
     stub_request(:post, "https://api.productive.io/api/v2/bookings")
-      .with(
-        body: {
-          "data" => {
-            "type" => "bookings",
-            "relationships" => {
-              "person" => {
-                "data" => {
-                  "type" => "people",
-                  "id" => employee.productive_id
-                }
-              },
-              "service" => {
-                "data" => nil
-              }
-            },
-            "attributes" => {
-              "started_on" => "2021-03-01",
-              "ended_on" => "2021-03-01",
-              "approved" => true,
-              "time" => 420
-            }
-          }
-        }.to_json
-      ).to_return(status: 200, body: "", headers: {})
+      .to_return(status: 200, body: "", headers: {})
   end
 
   def stub_booking_delete(id)

--- a/spec/support_rota_to_productive/import_spec.rb
+++ b/spec/support_rota_to_productive/import_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe SupportRotaToProductive::Import do
   let(:dry_run) { false }
   subject { described_class.new(dry_run: dry_run) }
 
-  let!(:service_request) { stub_productive_service(SupportRotaToProductive::Booking::SUPPORT_SERVICE_ID) }
+  let!(:service_request) { stub_productive_service(SupportRotaToProductive::SendToProductive::SUPPORT_SERVICE_ID) }
   let!(:support_rota_request_dev) { stub_support_rota_service("dev") }
   let!(:support_rota_request_ops) { stub_support_rota_service("ops") }
   let!(:dev_employee) { FactoryBot.create(:employee, email: "joe@dxw.com") }
   let!(:ops_employee) { FactoryBot.create(:employee, email: "petra@dxw.com") }
 
   before do
-    allow(SupportRotaToProductive::Booking::LOGGER).to receive(:info)
-    allow_any_instance_of(SupportRotaToProductive::Booking).to receive(:employee_assigned_to_support_project?).and_return(true)
+    allow(SupportRotaToProductive::SendToProductive::LOGGER).to receive(:info)
+    allow_any_instance_of(SupportRotaToProductive::SendToProductive).to receive(:employee_assigned_to_support_project?).and_return(true)
   end
 
   describe "#run" do
@@ -41,7 +41,7 @@ RSpec.describe SupportRotaToProductive::Import do
     end
 
     it "logs the creation of the booking" do
-      expect(SupportRotaToProductive::Booking::LOGGER).to have_received(:info).with(
+      expect(SupportRotaToProductive::SendToProductive::LOGGER).to have_received(:info).with(
         "Creating support shift for joe@dxw.com on 2021-03-01"
       )
     end
@@ -54,7 +54,7 @@ RSpec.describe SupportRotaToProductive::Import do
 
     it "logs the deletion of each booking" do
       existing_bookings.each do |booking|
-        expect(SupportRotaToProductive::Booking::LOGGER).to have_received(:info).with(
+        expect(SupportRotaToProductive::SendToProductive::LOGGER).to have_received(:info).with(
           "Deleting support shift for #{booking.person.email} on #{booking.started_on}"
         )
       end
@@ -70,7 +70,7 @@ RSpec.describe SupportRotaToProductive::Import do
       end
 
       it "logs the creation of the booking" do
-        expect(SupportRotaToProductive::Booking::LOGGER).to have_received(:info).with(
+        expect(SupportRotaToProductive::SendToProductive::LOGGER).to have_received(:info).with(
           "Creating support shift for joe@dxw.com on 2021-03-01"
         )
       end
@@ -83,7 +83,7 @@ RSpec.describe SupportRotaToProductive::Import do
 
       it "logs the deletion of each booking" do
         existing_bookings.each do |booking|
-          expect(SupportRotaToProductive::Booking::LOGGER).to have_received(:info).with(
+          expect(SupportRotaToProductive::SendToProductive::LOGGER).to have_received(:info).with(
             "Deleting support shift for #{booking.person.email} on #{booking.started_on}"
           )
         end

--- a/spec/support_rota_to_productive/import_spec.rb
+++ b/spec/support_rota_to_productive/import_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SupportRotaToProductive::Import do
   let(:dry_run) { false }
   subject { described_class.new(dry_run: dry_run) }
 
-  let!(:service_request) { stub_productive_service(SupportRotaToProductive::SendToProductive::SUPPORT_SERVICE_ID) }
+  let!(:service_request) { stub_productive_service(SupportRotaToProductive::SUPPORT_SERVICE_ID) }
   let!(:support_rota_request_dev) { stub_support_rota_service("dev") }
   let!(:support_rota_request_ops) { stub_support_rota_service("ops") }
   let!(:dev_employee) { FactoryBot.create(:employee, email: "joe@dxw.com") }

--- a/spec/support_rota_to_productive/send_to_productive_spec.rb
+++ b/spec/support_rota_to_productive/send_to_productive_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe SupportRotaToProductive::Booking do
+RSpec.describe SupportRotaToProductive::SendToProductive do
   let(:employee) { create(:employee, email: "foo@example.com") }
   let(:support_rotation) { create(:support_rotation, employee: employee) }
   let(:dry_run) { false }
@@ -17,11 +17,11 @@ RSpec.describe SupportRotaToProductive::Booking do
       allow(subject).to receive(:employee_assigned_to_support_project?).and_return(true)
     end
 
-    let!(:service_request) { stub_productive_service(SupportRotaToProductive::Booking::SUPPORT_SERVICE_ID) }
+    let!(:service_request) { stub_productive_service(SupportRotaToProductive::SendToProductive::SUPPORT_SERVICE_ID) }
 
     context "when a person exists in Productive" do
       let!(:project_assignment_request) {
-        stub_project_assignment_for_employee_and_project(employee.productive_id, SupportRotaToProductive::Booking::SUPPORT_PROJECT_ID)
+        stub_project_assignment_for_employee_and_project(employee.productive_id, SupportRotaToProductive::SendToProductive::SUPPORT_PROJECT_ID)
       }
       let!(:booking_request) { stub_booking_create(employee: employee) }
 

--- a/spec/support_rota_to_productive/send_to_productive_spec.rb
+++ b/spec/support_rota_to_productive/send_to_productive_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe SupportRotaToProductive::SendToProductive do
       allow(subject).to receive(:employee_assigned_to_support_project?).and_return(true)
     end
 
-    let!(:service_request) { stub_productive_service(SupportRotaToProductive::SendToProductive::SUPPORT_SERVICE_ID) }
+    let!(:service_request) { stub_productive_service(SupportRotaToProductive::SUPPORT_SERVICE_ID) }
 
     context "when a person exists in Productive" do
       let!(:project_assignment_request) {
-        stub_project_assignment_for_employee_and_project(employee.productive_id, SupportRotaToProductive::SendToProductive::SUPPORT_PROJECT_ID)
+        stub_project_assignment_for_employee_and_project(employee.productive_id, SupportRotaToProductive::SUPPORT_PROJECT_ID)
       }
       let!(:booking_request) { stub_booking_create(employee: employee) }
 

--- a/spec/support_rota_to_productive/send_to_productive_spec.rb
+++ b/spec/support_rota_to_productive/send_to_productive_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SupportRotaToProductive::SendToProductive do
   subject { described_class.new(support_rotation, dry_run) }
 
   before do
-    allow(described_class::LOGGER).to receive(:info)
+    allow(SupportRotaToProductive::LOGGER).to receive(:info)
   end
 
   describe "#save" do
@@ -23,7 +23,7 @@ RSpec.describe SupportRotaToProductive::SendToProductive do
       let!(:project_assignment_request) {
         stub_project_assignment_for_employee_and_project(employee.productive_id, SupportRotaToProductive::SUPPORT_PROJECT_ID)
       }
-      let!(:booking_request) { stub_booking_create(employee: employee) }
+      let!(:booking_request) { stub_booking_create }
 
       it "creates a booking in productive" do
         subject.save
@@ -34,7 +34,7 @@ RSpec.describe SupportRotaToProductive::SendToProductive do
       it "logs the creation of a booking" do
         subject.save
 
-        expect(described_class::LOGGER).to have_received(:info).with("Creating support shift for #{employee.email} on #{support_rotation.date}")
+        expect(SupportRotaToProductive::LOGGER).to have_received(:info).with("Creating support shift for #{employee.email} on #{support_rotation.date}")
       end
 
       context "but they are not assigned to the support project" do
@@ -61,7 +61,7 @@ RSpec.describe SupportRotaToProductive::SendToProductive do
         it "logs the creation of a booking" do
           subject.save
 
-          expect(described_class::LOGGER).to have_received(:info).with("Creating support shift for #{employee.email} on #{support_rotation.date}")
+          expect(SupportRotaToProductive::LOGGER).to have_received(:info).with("Creating support shift for #{employee.email} on #{support_rotation.date}")
         end
       end
     end
@@ -75,7 +75,7 @@ RSpec.describe SupportRotaToProductive::SendToProductive do
       it "shows a log message" do
         subject.save
 
-        expect(described_class::LOGGER).to have_received(:info).with("Cannot find an entry in Productive for #{employee.email}")
+        expect(SupportRotaToProductive::LOGGER).to have_received(:info).with("Cannot find an entry in Productive for #{employee.email}")
       end
 
       it "does not create a booking in productive" do
@@ -96,25 +96,8 @@ RSpec.describe SupportRotaToProductive::SendToProductive do
         it "logs the creation of a booking" do
           subject.save
 
-          expect(described_class::LOGGER).to have_received(:info).with("Cannot find an entry in Productive for #{employee.email}")
+          expect(SupportRotaToProductive::LOGGER).to have_received(:info).with("Cannot find an entry in Productive for #{employee.email}")
         end
-      end
-    end
-  end
-
-  describe ".delete_all_future_bookings" do
-    let!(:bookings) { create_list(:booking, 6) }
-    let!(:delete_stubs) do
-      bookings.map do |booking|
-        stub_booking_delete(booking.id)
-      end
-    end
-
-    it "deletes all future bookings" do
-      described_class.delete_all_future_bookings(dry_run)
-
-      delete_stubs.each do |stub|
-        expect(stub).to have_been_requested
       end
     end
   end

--- a/spec/support_rota_to_productive/support_rotation_spec.rb
+++ b/spec/support_rota_to_productive/support_rotation_spec.rb
@@ -8,14 +8,34 @@ RSpec.describe SupportRotaToProductive::SupportRotation do
 
   describe ".new" do
     subject { support_rotation }
+
     it { should be_a(SupportRotaToProductive::SupportRotation) }
   end
 
-  describe ".all" do
-    it "returns all developer & ops support shifts as SupportRotation objects" do
-      expect(SupportRotaToProductive::SupportRotation.all).to be_an(Array)
-      expect(SupportRotaToProductive::SupportRotation.all.count).to eq(4)
-      expect(SupportRotaToProductive::SupportRotation.all.first).to be_a(SupportRotaToProductive::SupportRotation)
+  describe ".from_support_rota" do
+    before do
+      stub_support_rota_service("dev")
+      stub_support_rota_service("ops")
+    end
+
+    let(:support_rotations) { described_class.from_support_rota }
+
+    it "returns support rotations" do
+      created_support_rotations = create_list(:support_rotation, 4)
+
+      expect(support_rotations.count).to eq(created_support_rotations.count)
+      expect(support_rotations.first).to be_a(SupportRotaToProductive::SupportRotation)
+    end
+  end
+
+  describe ".from_productive" do
+    let(:support_rotations) { described_class.from_productive }
+
+    it "returns bookings as support_rotations" do
+      created_support_rotations = create_list(:booking, 6)
+
+      expect(support_rotations.count).to eq(created_support_rotations.count)
+      expect(support_rotations.first).to be_a(SupportRotaToProductive::SupportRotation)
     end
   end
 

--- a/spec/support_rota_to_productive/support_rotation_spec.rb
+++ b/spec/support_rota_to_productive/support_rotation_spec.rb
@@ -18,4 +18,40 @@ RSpec.describe SupportRotaToProductive::SupportRotation do
       expect(SupportRotaToProductive::SupportRotation.all.first).to be_a(SupportRotaToProductive::SupportRotation)
     end
   end
+
+  describe "#eql?" do
+    let(:support_rotation_1) { create(:support_rotation, employee: employee, date: Date.today) }
+    let(:support_rotation_2) { create(:support_rotation, employee: employee, date: Date.today) }
+    let(:support_rotation_3) { create(:support_rotation) }
+
+    it "returns true if the objects have the same attributes" do
+      expect(support_rotation_1).to eq(support_rotation_2)
+    end
+
+    it "returns false if the objects don't have the same attributes" do
+      expect(support_rotation_1).to_not eq(support_rotation_3)
+    end
+
+    context "with arrays" do
+      let(:extra_item) { create(:support_rotation) }
+
+      let(:support_rotation_list_1) do
+        [
+          create(:support_rotation, date: Date.parse("2021-01-01"), employee: employee),
+          create(:support_rotation, date: Date.parse("2021-02-01"), employee: employee),
+          create(:support_rotation, date: Date.parse("2021-03-01"), employee: employee)
+        ]
+      end
+      let(:support_rotation_list_2) do
+        [
+          *support_rotation_list_1,
+          extra_item
+        ]
+      end
+
+      it "matches two arrays of objects" do
+        expect(support_rotation_list_2 - support_rotation_list_1).to eq([extra_item])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is completely repurposed from https://github.com/dxw/breathe-to-productive/pull/2/ - thank you @pezholio !

Previously we were updating the Support shifts (rotations) in Productive by removing all future support shifts, then recreating them. This was effective but the "nuclear" option. We wanted to be able to examine what is in Productive already, and only remove/recreate any support shifts which had changed in the Support Rota API. 

This PR achieves this by casting the support shifts in Productive and the support shifts in the Support Rota API to the same type of object, comparing them, and updating only any which differ. 
