### PR TITLE
Schedule script to sync support time automatically

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,0 +1,30 @@
+name: Run
+env:
+  PRODUCTIVE_ACCOUNT_ID: ${{ secrets.PRODUCTIVE_ACCOUNT_ID }}
+  PRODUCTIVE_API_KEY: ${{ secrets.PRODUCTIVE_API_KEY }}
+  SUPPORT_PROJECT_ID: ${{ secrets.SUPPORT_PROJECT_ID }}
+  SUPPORT_SERVICE_ID: ${{ secrets.SUPPORT_SERVICE_ID }}
+  SUPPORT_ROTA_API_URI: https://dxw-support-rota.herokuapp.com
+  IMPORT_DEV_IN_HOURS: true
+  IMPORT_OPS_IN_HOURS: true
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1-5'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Import
+        id: import
+        run: |
+          bundle exec rake support_rota_to_productive:import:dry_run && \
+          bundle exec rake support_rota_to_productive:import:run

--- a/lib/support_rota_to_productive/import.rb
+++ b/lib/support_rota_to_productive/import.rb
@@ -15,7 +15,7 @@ module SupportRotaToProductive
       end.reduce(0) { |count| count + 1 }
 
       LOGGER.info("==========================================================")
-      LOGGER.info("Run complete!")
+      LOGGER.info("#{@dry_run ? "Dry run" : "Run"} complete!")
       LOGGER.info("#{added} item(s) added, #{deleted} item(s) deleted")
       LOGGER.info("==========================================================")
     end


### PR DESCRIPTION
# Changes

- Tell the user if a DRY run was used as opposed to the real thing, to help debugging
- Scheduled task to run the rake task at 3am on weekdays
- Scheduled tasks can be run manually through the GitHub UI by including the `workflow_dispatch` trigger
- Tasks only try once. We had been looking at doing 4 attempts based on the approach from [Breathe to Productive](https://github.com/dxw/breathe-to-productive/commit/c78751269f18112a304140aa2cd679e44210961a#diff-a3ddd7238fc6e36daeb0ef76e93fe15cc87824bd3299888075210c5ca6a474d3). We didn't think this was needed as it seems to work first time and suspect it is a precaution against the old 10k ft API being more fragile

I have added 4 required environment variables to GitHub Secrets already.

⚠️ I am concerned that `SERVICE_ID` may not be set correctly. I had to create a new service myself by editing the buget of the [1st line support (in hours) project](https://app.productive.io/15642-dxw/projects/129937/budgets?filter=LTE%3D). I called it Support days. **I am not sure if this is how we're meant to (or want to) use Productive?**

That said I did run it for real from my local machine, adding content only for my email address. It looks to have correctly added my support for this week. You can check [the full thread and screenshots here](https://dxw.slack.com/archives/C01VAEC7TUJ/p1622813766008500?thread_ts=1622803100.004200&cid=C01VAEC7TUJ). If this is not correct, you can delete all bookings for my email address to get back to where we were before I started.