### PR TITLE
Fix the ignoring of productive contacts that have emails in uppercase

### DIFF
--- a/lib/support_rota_to_productive/employee.rb
+++ b/lib/support_rota_to_productive/employee.rb
@@ -4,7 +4,7 @@ module SupportRotaToProductive
     attr_accessor :email
 
     def to_productive
-      @to_productive ||= self.class.all_productive_employees.find { |e| e.email == email }
+      @to_productive ||= self.class.all_productive_employees.find { |e| e.email.downcase == email.downcase }
     end
 
     def productive_id

--- a/spec/factories/employee.rb
+++ b/spec/factories/employee.rb
@@ -8,10 +8,6 @@ FactoryBot.define do
 
     skip_create
 
-    after(:create) do |employee, evaluator|
-      create(:person, email: employee.email) if evaluator.in_productive?
-    end
-
     trait :not_in_productive do
       transient do
         in_productive? { false }

--- a/spec/factories/person.rb
+++ b/spec/factories/person.rb
@@ -5,62 +5,27 @@ FactoryBot.define do
     first_name { FFaker::Name.first_name }
     last_name { FFaker::Name.first_name }
 
-    transient do
-      json {
-        {
-          id: id,
-          type: "people",
-          attributes: {
-            first_name: FFaker::Name.first_name,
-            last_name: FFaker::Name.last_name,
-            email: email,
-            title: nil,
-            joined_at: "2021-04-16T17:39:56.000+02:00",
-            last_seen_at: "2021-04-30T11:36:23.727+02:00",
-            deactivated_at: nil,
-            archived_at: nil,
-            role_id: 12,
-            invited_at: "2021-04-16T17:06:30.000+02:00",
-            is_user: true,
-            user_id: id,
-            tag_list: [],
-            avatar_url: nil,
-            virtual: false,
-            custom_fields: nil,
-            autotracking: false,
-            created_at: "2021-04-16T17:06:29.711+02:00",
-            placeholder: false,
-            color_id: nil,
-            private_custom_reports_used: 0,
-            contact: {},
-            sample_data: nil
-          },
-          relationships: {
-            organization: {data: {type: "organizations", id: 15071}},
-            company: {data: {type: "companies", id: "180872"}},
-            subsidiary: {data: {type: "subsidiaries", id: "14723"}}
-          }
-        }
-      }
-    end
+    title { nil }
+    joined_at { "2021-04-16T17:39:56.000+02:00" }
+    last_seen_at { "2021-04-30T11:36:23.727+02:00" }
+    deactivated_at { nil }
+    archived_at { nil }
+    role_id { 12 }
+    invited_at { "2021-04-16T17:06:30.000+02:00" }
+    is_user { true }
+    user_id { id }
+    tag_list { [] }
+    avatar_url { nil }
+    virtual { false }
+    custom_fields { nil }
+    autotracking { false }
+    created_at { "2021-04-16T17:06:29.711+02:00" }
+    placeholder { false }
+    color_id { nil }
+    private_custom_reports_used { 0 }
+    contact { {} }
+    sample_data { nil }
 
     skip_create
-
-    after(:create) do |absence, evaluator|
-      @json ||= {
-        "data" => []
-      }
-      @json["data"] << evaluator.json
-
-      url = "https://api.productive.io/api/v2/people"
-      WebMock.stub_request(:get, url)
-        .to_return(
-          status: 200,
-          body: @json.to_json,
-          headers: {
-            "Content-Type" => "application/json"
-          }
-        )
-    end
   end
 end

--- a/spec/support/service_stubs.rb
+++ b/spec/support/service_stubs.rb
@@ -69,9 +69,27 @@ module ServiceStubs
       .to_return(status: 200, body: "", headers: {})
   end
 
-  def stub_people
+  def stub_people(people: [])
+    body = {"data" => [], "included" => []}
+
+    unless people.empty?
+      people.map do |person|
+        person_data = {id: "1", type: "people", attributes: {}}
+        person_data[:attributes] = person.attributes.as_json
+        person_data[:relationships] = {
+          relationships: {
+            organization: {data: {type: "organizations", id: 15071}},
+            company: {data: {type: "companies", id: "180872"}},
+            subsidiary: {data: {type: "subsidiaries", id: "14723"}}
+          }
+        }
+
+        body["data"] << person_data
+      end
+    end
+
     stub_request(:get, "https://api.productive.io/api/v2/people")
-      .to_return(status: 200, body: "", headers: {})
+      .to_return(status: 200, body: body.to_json, headers: {"Content-Type" => "application/json"})
   end
 end
 

--- a/spec/support_rota_to_productive/employee_spec.rb
+++ b/spec/support_rota_to_productive/employee_spec.rb
@@ -1,21 +1,23 @@
 require "spec_helper"
 
 RSpec.describe SupportRotaToProductive::Employee do
-  let(:employee) { create(:employee, email: "foo@example.com") }
-
   describe ".new" do
-    subject { employee }
-
-    it { should be_a(SupportRotaToProductive::Employee) }
+    it "should return an Employee object" do
+      result = described_class.new
+      expect(result).to be_a(SupportRotaToProductive::Employee)
+    end
   end
 
   describe "#to_productive" do
-    subject { employee.to_productive }
+    it "returns a Productive person object" do
+      productive_employee = build(:employee, email: "foo@example.com")
+      support_rota_person = create(:person, email: "foo@example.com")
+      stub_people(people: [support_rota_person])
 
-    it "returns an employee's representation in productive" do
-      expect(subject).to be_a(Productive::Person)
+      result = productive_employee.to_productive
 
-      expect(subject.email).to eq("foo@example.com")
+      expect(result).to be_a(Productive::Person)
+      expect(result.email).to eq("foo@example.com")
     end
   end
 end

--- a/spec/support_rota_to_productive/employee_spec.rb
+++ b/spec/support_rota_to_productive/employee_spec.rb
@@ -19,5 +19,29 @@ RSpec.describe SupportRotaToProductive::Employee do
       expect(result).to be_a(Productive::Person)
       expect(result.email).to eq("foo@example.com")
     end
+
+    context "when the productive email is up case" do
+      it "continues to return a Productive person" do
+        support_rota_person = create(:person, email: "foo@EXAMPLE.com")
+        stub_people(people: [support_rota_person])
+
+        productive_employee = build(:employee, email: "foo@example.com")
+        result = productive_employee.to_productive
+
+        expect(result).to be_a(Productive::Person)
+      end
+    end
+
+    context "when the support rota email is up case" do
+      it "continues to return a Productive person" do
+        support_rota_person = create(:person, email: "foo@example.com")
+        stub_people(people: [support_rota_person])
+
+        productive_employee = build(:employee, email: "foo@EXAMPLE.com")
+        result = productive_employee.to_productive
+
+        expect(result).to be_a(Productive::Person)
+      end
+    end
   end
 end

--- a/spec/support_rota_to_productive/import_spec.rb
+++ b/spec/support_rota_to_productive/import_spec.rb
@@ -123,8 +123,9 @@ RSpec.describe SupportRotaToProductive::Import do
   end
 
   def create_and_stub_person(email:)
-    employee = FactoryBot.create(:employee, email: email)
+    employee = create(:employee, email: email)
     person = create(:person, email: employee.email)
+    stub_people(people: [person])
     stub_project_assignment_for_employee_and_project(
       employee.productive_id, SupportRotaToProductive::SUPPORT_PROJECT_ID
     )


### PR DESCRIPTION
We had at least one member of staff who wasn't having their time added to Productive. Their email in Productive was x@DXW.com rather than dxw.com. I couldn't see a way to edit this within Productive and even if I could that isn't a robust fix as it could happen again.

This change does some refactoring and then improves the comparison by downcasing emails before checking for equality.

- refactor FactoryBot transient stubbing into explict test helper methods so they can be modified
- refactor the test suite to use less `let` statements to make the tests easier to reason about
- remove some redundant set up and stubbing from the employee test file
- fix the ignoring of productive contacts that have emails in uppercase (in Productive)
- fix the ignoring of emploee emails that have emails in uppercase (in the Suppport rota)