### PR TITLE
Guard against users who don't have an email address

### DIFF
--- a/lib/support_rota_to_productive/employee.rb
+++ b/lib/support_rota_to_productive/employee.rb
@@ -4,7 +4,9 @@ module SupportRotaToProductive
     attr_accessor :email
 
     def to_productive
-      @to_productive ||= self.class.all_productive_employees.find { |e| e.email.downcase == email.downcase }
+      @to_productive ||= self.class.all_productive_employees.find { |e|
+        e&.email&.downcase == email&.downcase
+      }
     end
 
     def productive_id

--- a/spec/support_rota_to_productive/employee_spec.rb
+++ b/spec/support_rota_to_productive/employee_spec.rb
@@ -43,5 +43,18 @@ RSpec.describe SupportRotaToProductive::Employee do
         expect(result).to be_a(Productive::Person)
       end
     end
+
+    context "when the email address is blank (as it's a placeholder user)" do
+      it "does not raise an error" do
+        placeholder_person = create(:person, email: nil)
+        support_person = create(:person, email: "someone_that_does_exist@dxw.com")
+        stub_people(people: [placeholder_person, support_person])
+
+        productive_employee = build(:employee, email: "someone_that_does_exist@dxw.com")
+        result = productive_employee.to_productive
+
+        expect(result).to be_a(Productive::Person)
+      end
+    end
   end
 end


### PR DESCRIPTION
Placeholder users, such as "Technology placeholder" do not have an email address. There is also a delivery placeholder.

The code now protects against this when comparing email addresses that is done when looking for users that _do_ exist.