### PR TITLE
Stop deleting and recreating all support events with different email …

### DIFF
--- a/lib/productive/booking.rb
+++ b/lib/productive/booking.rb
@@ -11,7 +11,7 @@ module Productive
     private
 
     def employee
-      SupportRotaToProductive::Employee.new(email: person.email)
+      SupportRotaToProductive::Employee.new(email: person.email.downcase)
     end
   end
 end

--- a/spec/productive/booking_spec.rb
+++ b/spec/productive/booking_spec.rb
@@ -13,5 +13,16 @@ RSpec.describe Productive::Booking do
       expect(subject.employee.email).to eq(booking.person.email)
       expect(subject.productive_booking).to eq(booking)
     end
+
+    context "when the Productive employee has an email that is not all lower case" do
+      it "lowercases it when creating SupportRotaToProductive::SupportRotation for reliable comparisons" do
+        productive_person = create(:person, email: "foo@DXW.com")
+        booking = create(:booking, person: productive_person)
+
+        result = booking.to_support_rotation
+
+        expect(result.employee.email).to eq("foo@dxw.com")
+      end
+    end
   end
 end


### PR DESCRIPTION
…casing

Before this change the script would incorrectly identify that there were x bookings in Productive that needed deleting.

Users in the Support rota all have fully lowercased email addresses.

When creating bookings we use the productive email address which includes this uppercase.

When we run the script again, we compare email addresses from the support rota and as they're lowercase, it detects a difference. It deletes them all, then recreates them all.