### PR TITLE
Update productive gem to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
-    productive (0.6.38)
+    productive (0.6.43)
       json_api_client (= 1.5.2)
       rack
       request_store (~> 1.3.2)


### PR DESCRIPTION
Recently Productive added a holiday calendar resource: https://github.com/productiveio/api_client/releases/tag/v0.6.43

The older version of the gem that we use crashes when encountering data from the API that includes references to this `HolidayCalendar` resource.

Updating to the latest version fixes it.