### PR TITLE
Update productive to 0.6.44

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
-    productive (0.6.43)
+    productive (0.6.44)
       json_api_client (= 1.5.2)
       rack
       request_store (~> 1.3.2)


### PR DESCRIPTION
This will fix the `NameError` when fetching bookings.