### PR TITLE
Handle the case of a placeholder person

### DIFF
--- a/lib/productive/booking.rb
+++ b/lib/productive/booking.rb
@@ -11,7 +11,7 @@ module Productive
     private
 
     def employee
-      SupportRotaToProductive::Employee.new(email: person.email.downcase)
+      SupportRotaToProductive::Employee.new(email: person&.email&.downcase || "delivery-placeholder@dxw.com")
     end
   end
 end


### PR DESCRIPTION
Entries in Productive can be assigned as placeholders.

Placeholder “people” don’t have an email address, so the script was breaking on `nil.downcase`.

Attempt to fix this by assigning a “delivery-placeholder” email.