### PR TITLE
Comment out the scheduled run

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -10,8 +10,8 @@ env:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 3 * * 1-5'
+  # schedule:
+  #  - cron: '0 3 * * 1-5'
 
 jobs:
   build:


### PR DESCRIPTION
We're not using this workflow right now, and it's failing with an authorisation error. Commenting out the scheduled run while keeping the workflow dispatch lets us attempt to fix it and trigger it manually when we have the chance.